### PR TITLE
Obituary creation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'bootstrap', '~> 4.0.0'
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'pry'
-  gem 'factory_bot'
+  gem 'factory_bot_rails'
   gem 'faker'
   gem 'rspec-rails'
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,9 @@ GEM
     execjs (2.7.0)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
+    factory_bot_rails (6.1.0)
+      factory_bot (~> 6.1.0)
+      railties (>= 5.0.0)
     faker (2.13.0)
       i18n (>= 1.6, < 2)
     faraday (1.0.1)
@@ -271,7 +274,7 @@ DEPENDENCIES
   byebug
   capybara
   coffee-rails (~> 4.2)
-  factory_bot
+  factory_bot_rails
   faker
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/controllers/obituaries_controller.rb
+++ b/app/controllers/obituaries_controller.rb
@@ -1,5 +1,5 @@
 class ObituariesController < ApplicationController
   def new
-
+    @obituary = Obituary.new
   end
 end

--- a/app/controllers/obituaries_controller.rb
+++ b/app/controllers/obituaries_controller.rb
@@ -8,6 +8,17 @@ class ObituariesController < ApplicationController
 
   def create
     @obituary = current_user.obituaries.new(obituary_params)
+    if @obituary.save
+      flash[:success] = 'Obituary Created'
+      redirect_to obituary_path(@obituary.id)
+    else
+      flash[:error] = @obituary.errors.full_messages.to_sentence
+      render :new
+    end
+  end
+
+  def show
+    @obituary = Obituary.find(params[:id])
   end
 
   private

--- a/app/controllers/obituaries_controller.rb
+++ b/app/controllers/obituaries_controller.rb
@@ -1,0 +1,5 @@
+class ObituariesController < ApplicationController
+  def new
+
+  end
+end

--- a/app/controllers/obituaries_controller.rb
+++ b/app/controllers/obituaries_controller.rb
@@ -1,7 +1,18 @@
 class ObituariesController < ApplicationController
   def index
   end
+
   def new
     @obituary = Obituary.new
+  end
+
+  def create
+    @obituary = current_user.obituaries.new(obituary_params)
+  end
+
+  private
+
+  def obituary_params
+    params.require(:obituary).permit(:first_name, :last_name, :description, :age, :city, :state, :image_url)
   end
 end

--- a/app/models/obituary.rb
+++ b/app/models/obituary.rb
@@ -1,2 +1,4 @@
 class Obituary < ApplicationRecord
+  validates_presence_of :first_name, :last_name
+  belongs_to :user
 end

--- a/app/models/obituary.rb
+++ b/app/models/obituary.rb
@@ -1,0 +1,2 @@
+class Obituary < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   validates :email, uniqueness:true, presence:true
   validates_presence_of :first_name, :last_name, :password
+  has_many :obituaries
 
   has_secure_password
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,7 @@
     <nav class="navbar-right navbar-light bg-light">
       <form class="form-inline">
         <% if current_user %>
+          <a href="/obituaries/new"><button class="btn btn-sm btn-outline-secondary" type="button">Add Obituary</button></a>
           <button class="btn btn-sm btn-outline-secondary" type="button">Logout</button>
         <% else %>
           <button class="btn btn-sm btn-outline-secondary" type="button">Login</button>

--- a/app/views/obituaries/_form.html.erb
+++ b/app/views/obituaries/_form.html.erb
@@ -7,7 +7,7 @@
   <%= f.text_field :last_name %>
 
   <%= f.label :age %>
-  <%= f.text_field :age %>
+  <%= f.number_field_tag :age, min: 0, max: 150 %>
 
   <%= f.label :city %>
   <%= f.text_field :city %>
@@ -16,7 +16,7 @@
   <%= f.text_field :state %>
 
   <%= f.label :description %>
-  <%= f.text_field :description %>
+  <%= f.text_field :description, :size => 150 %>
 
   <%= f.submit %>
 <% end %>

--- a/app/views/obituaries/_form.html.erb
+++ b/app/views/obituaries/_form.html.erb
@@ -7,7 +7,7 @@
   <%= f.text_field :last_name %>
 
   <%= f.label :age %>
-  <%= f.number_field_tag :age, min: 0, max: 150 %>
+  <%= f.number_field :age, min: 0, max: 150 %>
 
   <%= f.label :city %>
   <%= f.text_field :city %>
@@ -17,6 +17,9 @@
 
   <%= f.label :description %>
   <%= f.text_field :description, :size => 150 %>
+
+  <%= f.label :image_url %>
+  <%= f.text_field :image_url %>
 
   <%= f.submit %>
 <% end %>

--- a/app/views/obituaries/_form.html.erb
+++ b/app/views/obituaries/_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_for @obituary do |f| %>
+
+  <%= f.label :first_name %>
+  <%= f.text_field :first_name  %>
+
+  <%= f.label :last_name %>
+  <%= f.text_field :last_name %>
+
+  <%= f.label :age %>
+  <%= f.text_field :age %>
+
+  <%= f.label :city %>
+  <%= f.text_field :city %>
+
+  <%= f.label :state %>
+  <%= f.text_field :state %>
+
+  <%= f.label :description %>
+  <%= f.text_field :description %>
+
+  <%= f.submit %>
+<% end %>

--- a/app/views/obituaries/new.html.erb
+++ b/app/views/obituaries/new.html.erb
@@ -1,0 +1,3 @@
+<h1>Create New Obituary</h1>
+
+<%= render partial: 'form' %>

--- a/app/views/obituaries/show.html.erb
+++ b/app/views/obituaries/show.html.erb
@@ -1,0 +1,11 @@
+<div class="obituary-image">
+  <%= image_tag(@obituary.image_url) %>
+</div>
+
+<h1><%="#{@obituary.first_name} #{@obituary.last_name}"%></h1>
+
+<h2> Age: <%= @obituary.age %> </h2>
+<h2> City: <%= @obituary.city %> </h2>
+<h2> State: <%= @obituary.state %> </h2>
+
+<p><%= @obituary.description %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 
    get "/", to: "welcome#index"
 
-
    get '/profile', to: "users#show"
    resources :users, only: [:new, :create]
+   resources :obituaries, only: [:new]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,8 @@ Rails.application.routes.draw do
 
    get '/profile', to: "users#show"
    resources :users, only: [:new, :create]
-   resources :obituaries, only: [:new]
-   get "/obituaries", to: "obituaries#index"
+   resources :obituaries, only: [:index, :new, :create]
+   # get "/obituaries", to: "obituaries#index"
    namespace :obituaries do
      get 'covid-19', to: 'covid#index'
      get 'recent', to: 'recent#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,12 +5,11 @@ Rails.application.routes.draw do
 
    get '/profile', to: "users#show"
    resources :users, only: [:new, :create]
-   get "/obituaries", to: "obituaries#index"
    namespace :obituaries do
      get 'covid-19', to: 'covid#index'
      get 'recent', to: 'recent#index'
    end
-   resources :obituaries, only: [:new, :create, :show]
+   resources :obituaries, only: [:index, :new, :create, :show]
    get '/search', to: 'search#index'
    namespace :search do
      get 'advanced', to: 'advanced#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,12 +5,12 @@ Rails.application.routes.draw do
 
    get '/profile', to: "users#show"
    resources :users, only: [:new, :create]
-   resources :obituaries, only: [:index, :new, :create]
-   # get "/obituaries", to: "obituaries#index"
+   get "/obituaries", to: "obituaries#index"
    namespace :obituaries do
      get 'covid-19', to: 'covid#index'
      get 'recent', to: 'recent#index'
    end
+   resources :obituaries, only: [:new, :create, :show]
    get '/search', to: 'search#index'
    namespace :search do
      get 'advanced', to: 'advanced#index'

--- a/db/migrate/20200722193500_create_obituaries.rb
+++ b/db/migrate/20200722193500_create_obituaries.rb
@@ -1,0 +1,15 @@
+class CreateObituaries < ActiveRecord::Migration[5.1]
+  def change
+    create_table :obituaries do |t|
+      t.string :first_name
+      t.string :last_name
+      t.integer :age
+      t.string :city
+      t.string :state
+      t.string :description
+      t.string :image_url
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200722194908_add_user_to_obituaries.rb
+++ b/db/migrate/20200722194908_add_user_to_obituaries.rb
@@ -1,0 +1,5 @@
+class AddUserToObituaries < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :obituaries, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200722193500) do
+ActiveRecord::Schema.define(version: 20200722194908) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,8 @@ ActiveRecord::Schema.define(version: 20200722193500) do
     t.string "image_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_obituaries_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -36,4 +38,5 @@ ActiveRecord::Schema.define(version: 20200722193500) do
     t.integer "role", default: 0
   end
 
+  add_foreign_key "obituaries", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,29 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200721213935) do
+ActiveRecord::Schema.define(version: 20200722193500) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "obituaries", force: :cascade do |t|
+    t.string "first_name"
+    t.string "last_name"
+    t.integer "age"
+    t.string "city"
+    t.string "state"
+    t.string "description"
+    t.string "image_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"
     t.string "email"
     t.string "password_digest"
+    t.string "password_confirmation"
     t.integer "role", default: 0
   end
 

--- a/spec/factories/obituaries.rb
+++ b/spec/factories/obituaries.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :obituary do
+    first_name { "MyString" }
+    last_name { "MyString" }
+    age { 1 }
+    city { "MyString" }
+    state { "MyString" }
+    description { "MyString" }
+    image_url { "MyString" }
+  end
+end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :user do
+    email  { Faker::Internet.email }
+    first_name { Faker::Creature::Dog.name }
+    last_name { Faker::Artist.name }
+    password { Faker::Color.color_name }
+    role { :default }
+  end
+
+  factory :admin, parent: :user do
+    role { :admin }
+  end
+end

--- a/spec/features/obituaries/create_spec.rb
+++ b/spec/features/obituaries/create_spec.rb
@@ -20,8 +20,8 @@ describe "As a registered user" do
     fill_in :age, with: 100
     fill_in :city, with: 'Denver'
     fill_in :state, with: 'Colorado'
-    # page.execute_script("$('#person_birthdate').val('21/12/1980')")
-    # page.execute_script("$('#person_deathhdate').val('21/12/2012')")
+    fill_in :image_url, with: 'https://st.depositphotos.com/1763281/2304/i/950/depositphotos_23040102-stock-photo-smiling-man-with-thumbs-up.jpg'
+
     click_on "Create Obituary"
 
     obituary = Obituary.last
@@ -32,7 +32,5 @@ describe "As a registered user" do
     expect(page).to have_content(description)
     expect(page).to have_content(obituary.age)
     expect(page).to have_content(obituary.city)
-    expect(page).to have_content(obituary.s)
-    # Add expectation for dates
   end
 end

--- a/spec/features/obituaries/create_spec.rb
+++ b/spec/features/obituaries/create_spec.rb
@@ -33,5 +33,6 @@ describe "As a registered user" do
     expect(page).to have_content(obituary.age)
     expect(page).to have_content(obituary.city)
     expect(page).to have_content(obituary.state)
+    expect(page).to have_css('.obituary-image')
   end
 end

--- a/spec/features/obituaries/create_spec.rb
+++ b/spec/features/obituaries/create_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+describe "As a registered user" do
+  it "I can creat a new obituary", :js => true do
+    user = create(:user)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    first_name = 'New First Name'
+    last_name = 'New Last Name'
+    description = 'New Obituary Description'
+
+    visit root_path
+    click_on "Add Obituary"
+    expect(current_path).to eq('/obituaries/new')
+
+    fill_in :first_name, with: first_name
+    fill_in :last_name, with: last_name
+    fill_in :description, with: description
+    fill_in :age, with: 100
+    fill_in :city, with: 'Denver'
+    fill_in :state, with: 'Colorado'
+    # page.execute_script("$('#person_birthdate').val('21/12/1980')")
+    # page.execute_script("$('#person_deathhdate').val('21/12/2012')")
+    click_on "Create Obituary"
+
+    obituary = Obituary.last
+    expect(current_path).to eq("/obituaries/#{obituary.id}")
+    expect(page).to have_content('Obituary Created')
+    expect(page).to have_content(first_name)
+    expect(page).to have_content(last_name)
+    expect(page).to have_content(description)
+    # Add expectation for dates
+  end
+end

--- a/spec/features/obituaries/create_spec.rb
+++ b/spec/features/obituaries/create_spec.rb
@@ -10,7 +10,8 @@ describe "As a registered user" do
     description = 'New Obituary Description'
 
     visit '/'
-    click_on "Add Obituary"
+
+    click_link "Add Obituary"
     expect(current_path).to eq('/obituaries/new')
 
     fill_in :first_name, with: first_name

--- a/spec/features/obituaries/create_spec.rb
+++ b/spec/features/obituaries/create_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "As a registered user" do
-  it "I can creat a new obituary", :js => true do
+  it "I can creat a new obituary"do
     user = create(:user)
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
@@ -9,7 +9,7 @@ describe "As a registered user" do
     last_name = 'New Last Name'
     description = 'New Obituary Description'
 
-    visit root_path
+    visit '/'
     click_on "Add Obituary"
     expect(current_path).to eq('/obituaries/new')
 
@@ -29,6 +29,9 @@ describe "As a registered user" do
     expect(page).to have_content(first_name)
     expect(page).to have_content(last_name)
     expect(page).to have_content(description)
+    expect(page).to have_content(obituary.age)
+    expect(page).to have_content(obituary.city)
+    expect(page).to have_content(obituary.s)
     # Add expectation for dates
   end
 end

--- a/spec/features/obituaries/create_spec.rb
+++ b/spec/features/obituaries/create_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "As a registered user" do
-  it "I can creat a new obituary"do
+  it "I can create a new obituary"do
     user = create(:user)
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
@@ -34,5 +34,17 @@ describe "As a registered user" do
     expect(page).to have_content(obituary.city)
     expect(page).to have_content(obituary.state)
     expect(page).to have_css('.obituary-image')
+  end
+
+  it "I can must fill in first and last name when creating a obituary"do
+    user = create(:user)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit '/'
+    click_link "Add Obituary"
+
+    click_on "Create Obituary"
+
+    expect(page).to have_content("First name can't be blank and Last name can't be blank")
   end
 end

--- a/spec/features/obituaries/create_spec.rb
+++ b/spec/features/obituaries/create_spec.rb
@@ -14,13 +14,13 @@ describe "As a registered user" do
     click_link "Add Obituary"
     expect(current_path).to eq('/obituaries/new')
 
-    fill_in :first_name, with: first_name
-    fill_in :last_name, with: last_name
-    fill_in :description, with: description
-    fill_in :age, with: 100
-    fill_in :city, with: 'Denver'
-    fill_in :state, with: 'Colorado'
-    fill_in :image_url, with: 'https://st.depositphotos.com/1763281/2304/i/950/depositphotos_23040102-stock-photo-smiling-man-with-thumbs-up.jpg'
+    fill_in 'obituary[first_name]', with: first_name
+    fill_in 'obituary[last_name]', with: last_name
+    fill_in 'obituary[description]', with: description
+    fill_in 'obituary[age]', with: 100
+    fill_in 'obituary[city]', with: 'Denver'
+    fill_in 'obituary[state]', with: 'Colorado'
+    fill_in 'obituary[image_url]', with: 'https://st.depositphotos.com/1763281/2304/i/950/depositphotos_23040102-stock-photo-smiling-man-with-thumbs-up.jpg'
 
     click_on "Create Obituary"
 
@@ -32,5 +32,6 @@ describe "As a registered user" do
     expect(page).to have_content(description)
     expect(page).to have_content(obituary.age)
     expect(page).to have_content(obituary.city)
+    expect(page).to have_content(obituary.state)
   end
 end

--- a/spec/models/obituary_spec.rb
+++ b/spec/models/obituary_spec.rb
@@ -1,5 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Obituary, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'validations' do
+    it {should validate_presence_of(:first_name)}
+    it {should validate_presence_of(:last_name)}
+  end
+
+  describe 'relationships' do
+    it {should belong_to(:user)}
+  end
 end

--- a/spec/models/obituary_spec.rb
+++ b/spec/models/obituary_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Obituary, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,13 +1,14 @@
 require "rails_helper"
 
-
-
 describe User, type: :model do
-  describe "validation" do
-
+  describe "validations" do
     it {should validate_presence_of(:first_name)}
     it {should validate_presence_of(:last_name)}
     it {should validate_presence_of(:email)}
     it {should validate_presence_of(:password)}
+  end
+
+  describe "relationships" do
+    it {should have_many(:obituaries)}
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,6 +43,8 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
+  config.include FactoryBot::Syntax::Methods
+
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false
 


### PR DESCRIPTION
Added the ability for a user to create a new obituary.
Set up route for a logged-in user to click a button in the navbar and go through the new obituary form to the obituary show page to see the newly created obituary.
Added the one to many relationship between users and obituaries.
Added a sad path test for not filling out a name when creating an obituary, but still need to test that a visitor cant create one.