### PR TITLE
Obituary sad paths

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,4 +5,8 @@ class ApplicationController < ActionController::Base
   def current_user
    @current_user ||= User.find(session[:user_id]) if session[:user_id]
   end
+
+  def render_404
+    render file: '/public/404'
+  end
 end

--- a/app/controllers/obituaries_controller.rb
+++ b/app/controllers/obituaries_controller.rb
@@ -23,8 +23,8 @@ class ObituariesController < ApplicationController
   end
 
   def edit
-    render_404 if !current_user
     @obituary = Obituary.find(params[:id])
+    render_404 if !current_user || !current_user.has_obituary?(@obituary)
   end
 
   def update

--- a/app/controllers/obituaries_controller.rb
+++ b/app/controllers/obituaries_controller.rb
@@ -3,6 +3,7 @@ class ObituariesController < ApplicationController
   end
 
   def new
+    render_404 if !current_user
     @obituary = Obituary.new
   end
 

--- a/app/controllers/obituaries_controller.rb
+++ b/app/controllers/obituaries_controller.rb
@@ -22,6 +22,7 @@ class ObituariesController < ApplicationController
   end
 
   def edit
+    render_404 if !current_user
     @obituary = Obituary.find(params[:id])
   end
 

--- a/app/views/obituaries/show.html.erb
+++ b/app/views/obituaries/show.html.erb
@@ -1,5 +1,5 @@
 <div class="obituary-image">
-  <%= image_tag(@obituary.image_url) %>
+  <%= image_tag(@obituary.image_url) rescue image_tag 'https://image.shutterstock.com/image-vector/ui-image-placeholder-wireframes-apps-260nw-1037719204.jpg' %>
 </div>
 
 <h1><%="#{@obituary.first_name} #{@obituary.last_name}"%></h1>

--- a/spec/features/obituaries/create_spec.rb
+++ b/spec/features/obituaries/create_spec.rb
@@ -52,3 +52,16 @@ describe "As a registered user" do
     expect(page).to have_content("First name can't be blank and Last name can't be blank")
   end
 end
+
+describe "As a visitor" do
+  it "I see no link to add an obituary" do
+    visit '/'
+    expect(page).to_not have_content("Add Obituary")
+  end
+
+  it "I cannot access the obituary create form" do
+    obituary = create(:obituary)
+    visit new_obituary_path(obituary.id)
+    expect(page).to have_content('The page you were looking for doesn\'t exist (404)')
+  end
+end

--- a/spec/features/obituaries/destroy_spec.rb
+++ b/spec/features/obituaries/destroy_spec.rb
@@ -13,6 +13,15 @@ describe "As a registered user" do
     expect(page).to have_content("Obituary Deleted")
     expect(user.obituaries).to eq([])
   end
+
+  it "I cannot edit another user's obituary" do
+    user1 = create(:user)
+    user2 = create(:user)
+    obituary2 = create(:obituary, user_id: user2.id)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user1)
+    visit obituary_path(obituary2.id)
+    expect(page).to_not have_content("Delete")
+  end
 end
 
 describe "As a visitor" do

--- a/spec/features/obituaries/edit_spec.rb
+++ b/spec/features/obituaries/edit_spec.rb
@@ -45,7 +45,6 @@ describe "As a registered user" do
 
   it "I cannot edit another user's obituary" do
     user1 = create(:user)
-    obituary1 = create(:obituary, user_id: user1.id)
     user2 = create(:user)
     obituary2 = create(:obituary, user_id: user2.id)
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user1)

--- a/spec/features/obituaries/edit_spec.rb
+++ b/spec/features/obituaries/edit_spec.rb
@@ -51,7 +51,7 @@ describe "As a visitor" do
     expect(page).to_not have_content("Edit")
   end
 
-  it "I cannot access the obituary edit for" do
+  it "I cannot access the obituary edit form" do
     obituary = create(:obituary)
     visit edit_obituary_path(obituary.id)
     expect(page).to have_content('The page you were looking for doesn\'t exist (404)')

--- a/spec/features/obituaries/edit_spec.rb
+++ b/spec/features/obituaries/edit_spec.rb
@@ -42,6 +42,18 @@ describe "As a registered user" do
 
     expect(page).to have_content("First name can't be blank and Last name can't be blank")
   end
+
+  it "I cannot edit another user's obituary" do
+    user1 = create(:user)
+    obituary1 = create(:obituary, user_id: user1.id)
+    user2 = create(:user)
+    obituary2 = create(:obituary, user_id: user2.id)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user1)
+    visit obituary_path(obituary2.id)
+    expect(page).to_not have_content("Edit")
+    visit edit_obituary_path(obituary2.id)
+    expect(page).to have_content('The page you were looking for doesn\'t exist (404)')
+  end
 end
 
 describe "As a visitor" do

--- a/spec/features/obituaries/edit_spec.rb
+++ b/spec/features/obituaries/edit_spec.rb
@@ -50,4 +50,10 @@ describe "As a visitor" do
     visit obituary_path(obituary.id)
     expect(page).to_not have_content("Edit")
   end
+
+  it "I cannot access the obituary edit for" do
+    obituary = create(:obituary)
+    visit edit_obituary_path(obituary.id)
+    expect(page).to have_content('The page you were looking for doesn\'t exist (404)')
+  end
 end


### PR DESCRIPTION
Added 404 errors and removed links for visitors attempting to edit or delete an obituary.
Added sad path tests for obituary CRUD
Fixed the bug where the image for an obituary would throw an error if the user did not enter a valid image URL.